### PR TITLE
Update scheduler_client.py

### DIFF
--- a/boefjes/clients/scheduler_client.py
+++ b/boefjes/clients/scheduler_client.py
@@ -4,6 +4,7 @@ import requests
 from pydantic import BaseModel, parse_obj_as
 
 from boefjes.job import BoefjeMeta, NormalizerMeta
+from abc import ABC, abstractmethod
 
 
 class Queue(BaseModel):
@@ -16,12 +17,14 @@ class Task(BaseModel):
     item: Union[BoefjeMeta, NormalizerMeta]
 
 
-class SchedulerClientInterface:
+class SchedulerClientInterface(ABC):
+    @abstractmethod
     def get_queues(self) -> List[Queue]:
-        raise NotImplementedError()
+        pass
 
+    @abstractmethod
     def pop_task(self, queue: str) -> Optional[Task]:
-        raise NotImplementedError()
+        pass
 
 
 class SchedulerAPIClient(SchedulerClientInterface):


### PR DESCRIPTION
Instead of raising NotImplementedErrors now use ABC for the SchedulerClientInterface.
This prevents using the interface without explicitly overwriting the abstract methods and thus prevent runtime errors with implementors of this interface.
