### PR TITLE
LeakIX handle HTTP 204 response

### DIFF
--- a/boefjes/plugins/kat_leakix/main.py
+++ b/boefjes/plugins/kat_leakix/main.py
@@ -31,7 +31,7 @@ def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:
                 headers={"Accept": "application/json", "api-key": getenv("LEAKIX_API")},
             )
             page_counter += 1
-            if not response:
+            if not response or not response.content:
                 break
             response_json = response.json()
             if not response_json:


### PR DESCRIPTION
LeakIX API responses with `scope=leak` where there are no results for the query tend to return an empty HTTP 204 response.

Calling `.json()` on an empty 204 response, as is done in the LeakIX boefje, results in a `JSONDecodeError` making the boefje fail. 
```python
[ERROR] [runner] Error while running boefje module leakix[2e423ae3d7bb4207a458ee4e347b22bd]
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/requests/models.py", line 971, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.8/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.8/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/app/boefjes/boefjes/runner.py", line 74, in run
    self.boefje_meta, output = self.boefje_resource.module.run(
  File "/app/boefjes/boefjes/plugins/kat_leakix/main.py", line 36, in run
    response_json = response.json()
  File "/usr/local/lib/python3.8/site-packages/requests/models.py", line 975, in json
    raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)
requests.exceptions.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

This pull request proposes a quick fix for this by avoiding the `.json()` call on a requests object where the `content` is empty.