### PR TITLE
[bug] [shodan] log no info instead of failing boefje

### DIFF
--- a/boefjes/plugins/kat_shodan/main.py
+++ b/boefjes/plugins/kat_shodan/main.py
@@ -5,6 +5,8 @@ from typing import Tuple, Union
 import shodan
 
 from os import getenv
+from ipaddress import ip_address
+
 from boefjes.job_models import BoefjeMeta
 
 
@@ -13,11 +15,15 @@ def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:
     input_ = boefje_meta.arguments["input"]
     ip = input_["address"]
     results = {}
-    try:
-        results = api.host(ip)
-    except shodan.APIError as e:
-        if e.args[0] != "No information available for that IP.":
-            raise
-        logging.info(e)
+
+    if ip_address(ip).is_private:
+        logging.info("Private IP requested, I will not forward this to Shodan.")
+    else:
+        try:
+            results = api.host(ip)
+        except shodan.APIError as e:
+            if e.args[0] != "No information available for that IP.":
+                raise
+            logging.info(e)
 
     return boefje_meta, json.dumps(results)

--- a/boefjes/plugins/kat_shodan/main.py
+++ b/boefjes/plugins/kat_shodan/main.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Tuple, Union
 
 import shodan
@@ -8,10 +9,15 @@ from boefjes.job_models import BoefjeMeta
 
 
 def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:
-
     api = shodan.Shodan(getenv("SHODAN_API"))
     input_ = boefje_meta.arguments["input"]
     ip = input_["address"]
-    results = api.host(ip)
+    results = {}
+    try:
+        results = api.host(ip)
+    except shodan.APIError as e:
+        if e.args[0] != "No information available for that IP.":
+            raise
+        logging.info(e)
 
     return boefje_meta, json.dumps(results)

--- a/boefjes/plugins/kat_shodan/requirements.txt
+++ b/boefjes/plugins/kat_shodan/requirements.txt
@@ -1,1 +1,2 @@
 shodan==1.25.0
+ipaddress==1.0.23


### PR DESCRIPTION
Currently the Shodan boefje fails when there is no information about an IP: 
```python
[ERROR] [runner] Error while running boefje module shodan[6807ceab1b1f4a9eaf674be332131ae1]
Traceback (most recent call last):
  File "/app/boefjes/boefjes/runner.py", line 74, in run
    self.boefje_meta, output = self.boefje_resource.module.run(
  File "/app/boefjes/boefjes/plugins/kat_shodan/main.py", line 15, in run
    results = api.host(ip)
  File "/usr/local/lib/python3.8/site-packages/shodan/client.py", line 380, in host
    return self._request('/shodan/host/%s' % ','.join(ips), params)
  File "/usr/local/lib/python3.8/site-packages/shodan/client.py", line 340, in _request
    raise APIError(data['error'])
shodan.exception.APIError: No information available for that IP.
```

Therefore, as also indicated in the [`shodan-python`  documentation](https://shodan.readthedocs.io/en/latest/tutorial.html#searching-shodan), Shodan API requests should be wrapped in try/except statements. This pull request proposes to add an informational log when Shodan has no information about an IP (preventing the boefje to end up as 'failed') and to raise the original shodan exception for all other failures.