### PR TITLE
[log4shell] [#14] make REPLY_FQDN variable

### DIFF
--- a/boefjes/plugins/kat_log4shell/boefje.json
+++ b/boefjes/plugins/kat_log4shell/boefje.json
@@ -9,6 +9,8 @@
             "Finding",
             "CVEFindingType"
         ],
-        "environment_keys": [],
+        "environment_keys": [
+            "REPLY_FQDN"
+        ],
         "scan_level": 3
     }

--- a/boefjes/plugins/kat_log4shell/description.md
+++ b/boefjes/plugins/kat_log4shell/description.md
@@ -10,11 +10,11 @@ Log4shell scan expects a URL object as input.
 
 ### Output OOIs
 
-Log4shell outputs the following OOIs:
+Currently, output needs to be verified from the `REPLY_FQDN`. In the future Log4shell outputs the following OOIs:
 
-| OOI type  |Description|
-|-----------|---|
-| Finding   |Finding if RCE is possible|
+| OOI type | Description                |
+| -------- | -------------------------- |
+| Finding  | Finding if RCE is possible |
 
 ### Running Boefje
 

--- a/boefjes/plugins/kat_log4shell/main.py
+++ b/boefjes/plugins/kat_log4shell/main.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 import requests
 import urllib3
+import validators
 
 from boefjes.job_models import BoefjeMeta
 
@@ -15,7 +16,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(level=logging.INFO)
 
 TIMEOUT = 15
-REPLY_FQDN = getenv("REPLY_FQDN")  # "cve.stillekat.nl"
+REPLY_FQDN = getenv("REPLY_FQDN", "invalid")  # "cve.stillekat.nl"
 
 
 def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:
@@ -26,10 +27,14 @@ def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:
 
     schemes = ["http", "https"]
 
+    reply_fqdn = REPLY_FQDN.lower()
+    if not (reply_fqdn == "localhost" or validators.domain(reply_fqdn)):
+        raise ValueError(f"{REPLY_FQDN} is not a valid fully qualified domain name")
+
     output = {}
     for scheme in schemes:
         url = f"{scheme}://{host}/"
-        payloads = get_payloads(url, REPLY_FQDN, identifier)
+        payloads = get_payloads(url, reply_fqdn, identifier)
 
         checks = [check(url, payload, TIMEOUT) for payload in payloads.values()]
         header_checks = [

--- a/boefjes/plugins/kat_log4shell/main.py
+++ b/boefjes/plugins/kat_log4shell/main.py
@@ -1,5 +1,7 @@
 import json
 import logging
+
+from os import getenv
 from base64 import b64encode
 from typing import Tuple, Union, Optional, Dict
 from urllib.parse import urlparse
@@ -13,7 +15,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 logging.basicConfig(level=logging.INFO)
 
 TIMEOUT = 15
-REPLY_FQDN = "cve.stillekat.nl"
+REPLY_FQDN = getenv("REPLY_FQDN")  # "cve.stillekat.nl"
 
 
 def run(boefje_meta: BoefjeMeta) -> Tuple[BoefjeMeta, Union[bytes, str]]:

--- a/boefjes/plugins/kat_log4shell/schema.json
+++ b/boefjes/plugins/kat_log4shell/schema.json
@@ -1,0 +1,15 @@
+{
+    "title": "Arguments",
+    "type": "object",
+    "properties": {
+        "REPLY_FQDN": {
+            "title": "REPLY_FQDN",
+            "maxLength": 255,
+            "type": "string",
+            "description": "A trusted fully qualified domain name to catch callbacks, such as 'cve.stillekat.nl'."
+        }
+    },
+    "required": [
+        "REPLY_FQDN"
+    ]
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ psycopg2-binary==2.9.5
 pylxd==2.3.1
 pynacl==1.5.0
 sqlalchemy==1.4.42
+validators==0.20.0
 
 # Dev dependencies
 pytest==7.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ psycopg2-binary==2.9.5
 pylxd==2.3.1
 pynacl==1.5.0
 sqlalchemy==1.4.42
-validators=0.20.0
+validators==0.20.0
 git+https://github.com/minvws/nl-kat-octopoes@v1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ psycopg2-binary==2.9.5
 pylxd==2.3.1
 pynacl==1.5.0
 sqlalchemy==1.4.42
+validators=0.20.0
 git+https://github.com/minvws/nl-kat-octopoes@v1.3.0


### PR DESCRIPTION
Since KAT1.3 it is possible to add settings for boefjes. As a quick fix for https://github.com/minvws/nl-kat-boefjes/issues/14 this pull request introduces a REPLY_FQDN setting for the log4shell boefje. As long as there is no log4shell self-hosting option in KAT users can now use their own domain to pickup beacon pings.