### PR TITLE
fix ipv6 address notation in urls

### DIFF
--- a/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/plugins/kat_webpage_analysis/main.py
@@ -32,7 +32,7 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
     else:
         # Fall back to old hack-ip-into-url behavior, for either https with no adapter, or http.
         if ip:
-            url_parts = url_parts._replace(netloc="[%s]" % ip)
+            url_parts = url_parts._replace(netloc=f"[{ip}]")
             uri = urlunsplit(
                 [
                     url_parts.scheme,

--- a/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/plugins/kat_webpage_analysis/main.py
@@ -20,7 +20,6 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
 
     uri = get_uri(input_)
     ip = input_["website"]["ip_service"]["ip_port"]["address"]["address"]
-
     # Code from https://github.com/Roadmaster/forcediphttpsadapter/blob/master/example.py
     url_parts = urlparse(uri)
     hostname = url_parts.netloc
@@ -33,7 +32,7 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
     else:
         # Fall back to old hack-ip-into-url behavior, for either https with no adapter, or http.
         if ip:
-            url_parts = url_parts._replace(netloc=ip)
+            url_parts = url_parts._replace(netloc="[%s]" % ip)
             uri = urlunsplit(
                 [
                     url_parts.scheme,

--- a/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/plugins/kat_webpage_analysis/main.py
@@ -1,15 +1,15 @@
+import ipaddress
 import json
 import mimetypes
-from typing import Tuple, Union, List
-from boefjes.job_models import BoefjeMeta
-
 from os import getenv
+from typing import Tuple, Union, List
+from urllib.parse import urlparse, urlunsplit
+
 import requests
+from forcediphttpsadapter.adapters import ForcedIPHTTPSAdapter
 from requests import Session
 
-from urllib.parse import urlparse, urlunsplit
-from forcediphttpsadapter.adapters import ForcedIPHTTPSAdapter
-
+from boefjes.job_models import BoefjeMeta
 
 ALLOWED_CONTENT_TYPES = mimetypes.types_map.values()
 
@@ -32,7 +32,16 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
     else:
         # Fall back to old hack-ip-into-url behavior, for either https with no adapter, or http.
         if ip:
-            url_parts = url_parts._replace(netloc=f"[{ip}]")
+            try:
+                addr = ipaddress.ip_address(ip)
+            except ValueError:
+                # Not a valid IP address, so don't try to hack it into the URL
+                pass
+            else:
+                if addr.version == 6:
+                    # IPv6 addresses need to be wrapped in brackets
+                    url_parts = url_parts._replace(netloc=f"[{ip}]")
+
             uri = urlunsplit(
                 [
                     url_parts.scheme,


### PR DESCRIPTION
This fixes the notation of  IPv6 addresses in the url fed to the requests lib.
Original traceback from the boefje:

```
Traceback (most recent call last):
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/models.py", line 434, in prepare_url
    scheme, auth, host, port, path, query, fragment = parse_url(url)
  File "/var/www/html/.venv/lib/python3.8/site-packages/urllib3/util/url.py", line 397, in parse_url
    return six.raise_from(LocationParseError(source_url), None)
  File "<string>", line 3, in raise_from
urllib3.exceptions.LocationParseError: Failed to parse: http://2a00:d00::10/

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/www/boefjes_v1.5.1/boefjes/job_handler.py", line 136, in handle
    boefje_results = self.job_runner.run(boefje_meta, environment)
  File "/var/www/boefjes_v1.5.1/boefjes/local.py", line 37, in run
    return boefje_resource.module.run(boefje_meta)
  File "/var/www/boefjes_v1.5.1/boefjes/plugins/kat_webpage_analysis/main.py", line 49, in run
    response = session.get(
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/sessions.py", line 600, in get
    return self.request("GET", url, **kwargs)
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/sessions.py", line 573, in request
    prep = self.prepare_request(req)
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/sessions.py", line 484, in prepare_request
    p.prepare(
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/models.py", line 368, in prepare
    self.prepare_url(url, params)
  File "/var/www/html/.venv/lib/python3.8/site-packages/requests/models.py", line 436, in prepare_url
    raise InvalidURL(*e.args)
requests.exceptions.InvalidURL: Failed to parse: http://2a00:d00::10/

Failed to parse: http://2a00:d00::10/
```