### PR TITLE
Feature/failure mode writing raw files

### DIFF
--- a/boefjes/app.py
+++ b/boefjes/app.py
@@ -89,7 +89,7 @@ def start_working(
                 logger.exception("Popping task from scheduler failed")
                 time.sleep(10 * settings.poll_interval)
                 continue
-            except Exception:
+            except:  # noqa
                 logger.exception("Popping task from scheduler failed")
                 time.sleep(10 * settings.poll_interval)
                 continue
@@ -122,8 +122,7 @@ def get_runtime_manager(settings: Settings, queue: RuntimeManager.Queue, log_lev
 
     return SchedulerRuntimeManager(
         item_handler,
-        # Do not share a session between workers
-        client_factory,
+        client_factory,  # Do not share a session between workers
         settings,
         log_level,
     )

--- a/boefjes/clients/scheduler_client.py
+++ b/boefjes/clients/scheduler_client.py
@@ -1,6 +1,11 @@
 from typing import List, Optional, Union
 
 import requests
+import uuid
+
+from enum import Enum
+import datetime
+
 from boefjes.job_models import BoefjeMeta, NormalizerMeta
 from pydantic import BaseModel, parse_obj_as
 
@@ -10,16 +15,47 @@ class Queue(BaseModel):
     size: int
 
 
-class Task(BaseModel):
-    # This works because Pydantic cannot parse NormalizerMeta data to a BoefjeMeta
+class QueuePrioritizedItem(BaseModel):
+    """Representation of a queue.PrioritizedItem on the priority queue. Used
+    for unmarshalling of priority queue prioritized items to a JSON
+    representation.
+    """
+
+    id: uuid.UUID
+    priority: int
+    hash: Optional[str]
     data: Union[BoefjeMeta, NormalizerMeta]
+
+
+class TaskStatus(Enum):
+    """Status of a task."""
+
+    PENDING = "pending"
+    QUEUED = "queued"
+    DISPATCHED = "dispatched"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class Task(BaseModel):
+    id: str
+    scheduler_id: str
+    type: str
+    p_item: QueuePrioritizedItem
+    status: TaskStatus
+    created_at: datetime.datetime
+    modified_at: datetime.datetime
 
 
 class SchedulerClientInterface:
     def get_queues(self) -> List[Queue]:
         raise NotImplementedError()
 
-    def pop_task(self, queue: str) -> Optional[Task]:
+    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
+        raise NotImplementedError()
+
+    def patch_task(self, task_id: str, status: TaskStatus) -> None:
         raise NotImplementedError()
 
 
@@ -38,8 +74,18 @@ class SchedulerAPIClient(SchedulerClientInterface):
 
         return parse_obj_as(List[Queue], response.json())
 
-    def pop_task(self, queue: str) -> Optional[Task]:
+    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
         response = self._session.get(f"{self.base_url}/queues/{queue}/pop")
         self._verify_response(response)
 
-        return parse_obj_as(Optional[Task], response.json())
+        return parse_obj_as(Optional[QueuePrioritizedItem], response.json())
+
+    def patch_task(self, task_id: str, status: TaskStatus) -> None:
+        response = self._session.get(f"{self.base_url}/tasks/{task_id}")
+        self._verify_response(response)
+
+        task = parse_obj_as(Task, response.json())
+        task.status = status
+
+        response = self._session.patch(f"{self.base_url}/tasks/{task.id}", data=task.json())
+        self._verify_response(response)

--- a/boefjes/clients/scheduler_client.py
+++ b/boefjes/clients/scheduler_client.py
@@ -52,7 +52,7 @@ class SchedulerClientInterface:
     def get_queues(self) -> List[Queue]:
         raise NotImplementedError()
 
-    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
+    def pop_item(self, queue: str) -> Optional[QueuePrioritizedItem]:
         raise NotImplementedError()
 
     def patch_task(self, task_id: str, status: TaskStatus) -> None:
@@ -74,13 +74,14 @@ class SchedulerAPIClient(SchedulerClientInterface):
 
         return parse_obj_as(List[Queue], response.json())
 
-    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
+    def pop_item(self, queue: str) -> Optional[QueuePrioritizedItem]:
         response = self._session.get(f"{self.base_url}/queues/{queue}/pop")
         self._verify_response(response)
 
         return parse_obj_as(Optional[QueuePrioritizedItem], response.json())
 
     def patch_task(self, task_id: str, status: TaskStatus) -> None:
+        # The pop endpoint does not return the complete task object, so we retrieve it first.
         response = self._session.get(f"{self.base_url}/tasks/{task_id}")
         self._verify_response(response)
 

--- a/boefjes/job_models.py
+++ b/boefjes/job_models.py
@@ -2,7 +2,9 @@ import hashlib
 from datetime import datetime, timedelta
 from typing import Dict, Optional, List, Union, Literal
 
-from pydantic import BaseModel, Field, validator, Extra
+from pydantic import BaseModel, Field, Extra
+
+from boefjes.katalogus.models import Boefje, Normalizer
 
 
 class JobException(Exception):
@@ -23,28 +25,6 @@ class Job(BaseModel):
             return self.ended_at - self.started_at
         else:
             return None
-
-
-class Boefje(BaseModel):
-    id: str
-    version: Optional[str] = Field(default=None)
-
-    @validator("id")
-    def non_empty_id(cls, value: str):
-        if not value:
-            raise ValueError("Boefje id cannot be empty")
-        return value
-
-
-class Normalizer(BaseModel):
-    id: str  # To be phased out for an id
-    version: Optional[str] = Field(default=None)
-
-    @validator("id")
-    def non_empty_id(cls, value: str):
-        if not value:
-            raise ValueError("Normalizer id cannot be empty")
-        return value
 
 
 class BoefjeMeta(Job):

--- a/boefjes/job_models.py
+++ b/boefjes/job_models.py
@@ -2,9 +2,7 @@ import hashlib
 from datetime import datetime, timedelta
 from typing import Dict, Optional, List, Union, Literal
 
-from pydantic import BaseModel, Field, Extra
-
-from boefjes.katalogus.models import Boefje, Normalizer
+from pydantic import BaseModel, Field, Extra, constr
 
 
 class JobException(Exception):
@@ -25,6 +23,20 @@ class Job(BaseModel):
             return self.ended_at - self.started_at
         else:
             return None
+
+
+class Boefje(BaseModel):
+    """Identifier for Boefje in a BoefjeMeta"""
+
+    id: constr(min_length=1)
+    version: Optional[str] = Field(default=None)
+
+
+class Normalizer(BaseModel):
+    """Identifier for Normalizer in a NormalizerMeta"""
+
+    id: constr(min_length=1)
+    version: Optional[str] = Field(default=None)
 
 
 class BoefjeMeta(Job):

--- a/boefjes/katalogus/dependencies/plugins.py
+++ b/boefjes/katalogus/dependencies/plugins.py
@@ -16,7 +16,7 @@ from boefjes.katalogus.local_repository import (
     LocalPluginRepository,
     get_local_repository,
 )
-from boefjes.katalogus.models import Repository, PluginType
+from boefjes.katalogus.models import Repository, PluginType, RESERVED_LOCAL_ID
 from boefjes.katalogus.storage.interfaces import (
     RepositoryStorage,
     PluginEnabledStorage,
@@ -178,7 +178,7 @@ class PluginService:
         plugins = {}
 
         for repository in repositories:
-            if repository.id == LocalPluginRepository.RESERVED_ID:
+            if repository.id == RESERVED_LOCAL_ID:
                 continue
 
             try:

--- a/boefjes/katalogus/local_repository.py
+++ b/boefjes/katalogus/local_repository.py
@@ -17,15 +17,13 @@ from boefjes.plugins.models import (
     ENTRYPOINT_NORMALIZERS,
     ModuleException,
 )
-from boefjes.katalogus.models import PluginType, Boefje, Normalizer
+from boefjes.katalogus.models import PluginType, Boefje, Normalizer, RESERVED_LOCAL_ID
 
 
 logger = logging.getLogger(__name__)
 
 
 class LocalPluginRepository:
-    RESERVED_ID = "LOCAL"
-
     def __init__(self, path: Path):
         self.path = path
 
@@ -96,7 +94,7 @@ class LocalPluginRepository:
 
         for path, package in paths_and_packages:
             try:
-                boefje_resources.append(BoefjeResource(path, package, LocalPluginRepository.RESERVED_ID))
+                boefje_resources.append(BoefjeResource(path, package, RESERVED_LOCAL_ID))
             except ModuleException as exc:
                 logger.exception(exc)
 
@@ -107,7 +105,7 @@ class LocalPluginRepository:
             [NORMALIZER_DEFINITION_FILE, ENTRYPOINT_NORMALIZERS]
         )
         normalizer_resources = [
-            NormalizerResource(path, package, LocalPluginRepository.RESERVED_ID) for path, package in paths_and_packages
+            NormalizerResource(path, package, RESERVED_LOCAL_ID) for path, package in paths_and_packages
         ]
 
         return {resource.normalizer.id: resource for resource in normalizer_resources}
@@ -142,7 +140,7 @@ class LocalPluginRepository:
     def _boefje_to_plugin(boefje: BoefjeResource) -> Boefje:
         def_file = boefje.path / "boefje.json"
         def_obj = json.loads(def_file.read_text())
-        def_obj["repository_id"] = LocalPluginRepository.RESERVED_ID
+        def_obj["repository_id"] = RESERVED_LOCAL_ID
 
         return Boefje.parse_obj(def_obj)
 
@@ -150,7 +148,7 @@ class LocalPluginRepository:
     def _normalizer_to_plugin(normalizer: NormalizerResource) -> Normalizer:
         def_file = normalizer.path / "normalizer.json"
         def_obj = json.loads(def_file.read_text())
-        def_obj["repository_id"] = LocalPluginRepository.RESERVED_ID
+        def_obj["repository_id"] = RESERVED_LOCAL_ID
 
         return Normalizer.parse_obj(def_obj)
 

--- a/boefjes/katalogus/models.py
+++ b/boefjes/katalogus/models.py
@@ -5,6 +5,9 @@ from typing import Union, NewType, Optional, List, Literal, Set
 from pydantic import BaseModel, AnyHttpUrl, Field
 
 
+RESERVED_LOCAL_ID = "LOCAL"
+
+
 class Repository(BaseModel):
     id: str
     name: str
@@ -18,7 +21,7 @@ class Organisation(BaseModel):
 
 class Plugin(BaseModel):
     id: str
-    repository_id: str
+    repository_id: str = RESERVED_LOCAL_ID
     name: Optional[str]
     version: Optional[str]
     authors: Optional[List[str]]
@@ -35,15 +38,15 @@ class Plugin(BaseModel):
 class Boefje(Plugin):
     type: Literal["boefje"] = "boefje"
     scan_level: int = 1
-    consumes: Set[str]
+    consumes: Set[str] = Field(default_factory=set)
+    produces: List[str] = Field(default_factory=list)
     options: Optional[List[str]]
-    produces: List[str]  # mime types
 
 
 class Normalizer(Plugin):
     type: Literal["normalizer"] = "normalizer"
-    consumes: List[str]  # mime types (and/ or boefjes)
-    produces: List[str]  # oois
+    consumes: List[str] = Field(default_factory=list)  # mime types (and/ or boefjes)
+    produces: List[str] = Field(default_factory=list)  # oois
     enabled: bool = True
 
 

--- a/boefjes/katalogus/storage/memory.py
+++ b/boefjes/katalogus/storage/memory.py
@@ -1,7 +1,6 @@
 from typing import Dict, List
 
-from boefjes.katalogus.local_repository import LocalPluginRepository
-from boefjes.katalogus.models import Organisation, Repository
+from boefjes.katalogus.models import Organisation, Repository, RESERVED_LOCAL_ID
 from boefjes.katalogus.storage.interfaces import (
     OrganisationStorage,
     RepositoryStorage,
@@ -101,7 +100,7 @@ class PluginStatesStorageMemory(PluginEnabledStorage):
 
     def get_all_enabled(self, organisation_id: str) -> Dict[str, List[str]]:
         return {
-            LocalPluginRepository.RESERVED_ID: [
+            RESERVED_LOCAL_ID: [
                 key.split(".", maxsplit=1)[1]
                 for key, value in self._data.items()
                 if value and key.split(".", maxsplit=1)[0] == organisation_id

--- a/boefjes/katalogus/tests/test_plugin_service.py
+++ b/boefjes/katalogus/tests/test_plugin_service.py
@@ -4,7 +4,7 @@ from boefjes.config import settings
 from boefjes.katalogus.clients import MockPluginRepositoryClient
 from boefjes.katalogus.dependencies.plugins import PluginService
 from boefjes.katalogus.local_repository import LocalPluginRepository
-from boefjes.katalogus.models import Boefje, Normalizer, Bit, Repository
+from boefjes.katalogus.models import Boefje, Normalizer, Bit, Repository, RESERVED_LOCAL_ID
 from boefjes.katalogus.storage.interfaces import SettingsNotConformingToSchema
 from boefjes.katalogus.storage.memory import (
     PluginStatesStorageMemory,
@@ -234,10 +234,10 @@ class TestPluginsService(TestCase):
         self.service.create_setting("api_key", "24", self.organisation, plugin_id)
         assert self.service.get_setting_by_key("api_key", self.organisation, plugin_id) == "24"
 
-        self.service.update_by_id(LocalPluginRepository.RESERVED_ID, plugin_id, self.organisation, True)
+        self.service.update_by_id(RESERVED_LOCAL_ID, plugin_id, self.organisation, True)
 
-        self.service.update_by_id(LocalPluginRepository.RESERVED_ID, "test-boefje-1", new_org_id, True)
-        self.service.update_by_id(LocalPluginRepository.RESERVED_ID, "test-boefje-2", new_org_id, True)
+        self.service.update_by_id(RESERVED_LOCAL_ID, "test-boefje-1", new_org_id, True)
+        self.service.update_by_id(RESERVED_LOCAL_ID, "test-boefje-2", new_org_id, True)
 
         with self.assertRaises(KeyError):
             self.service.get_setting_by_key("api_key", new_org_id, plugin_id)

--- a/boefjes/runtime_interfaces.py
+++ b/boefjes/runtime_interfaces.py
@@ -26,7 +26,3 @@ class RuntimeManager:
 
     def run(self, queue: Queue) -> None:
         raise NotImplementedError()
-
-
-class StopWorking(Exception):
-    """Exception to tell workers in the runtime to stop working"""

--- a/boefjes/runtime_interfaces.py
+++ b/boefjes/runtime_interfaces.py
@@ -26,3 +26,7 @@ class RuntimeManager:
 
     def run(self, queue: Queue) -> None:
         raise NotImplementedError()
+
+
+class JobRuntimeError(RuntimeError):
+    """Base exception class for exceptions raised during running of jobs"""

--- a/boefjes/seed.py
+++ b/boefjes/seed.py
@@ -1,6 +1,7 @@
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
+from boefjes.katalogus.models import RESERVED_LOCAL_ID
 from boefjes.sql.db import get_engine
 from boefjes.sql.db_models import RepositoryInDB
 
@@ -9,7 +10,7 @@ def main():
     session = sessionmaker(bind=get_engine())()
 
     try:
-        session.add(RepositoryInDB(id="LOCAL", name="Local Plugin Repository", base_url="http://dev/null"))
+        session.add(RepositoryInDB(id=RESERVED_LOCAL_ID, name="Local Plugin Repository", base_url="http://dev/null"))
         session.commit()
     except IntegrityError:
         session.rollback()

--- a/tests/examples/scheduler/pop_response_boefje.json
+++ b/tests/examples/scheduler/pop_response_boefje.json
@@ -1,5 +1,8 @@
 {
+    "id": "70da7d4ff41f4940901bd98a92e9014b",
     "priority": 1,
+    "scheduler_id": "boefje-_dev",
+    "hash": "7e698c377cfd85015c0d7086b76b76b4",
     "data": {
         "id": "70da7d4ff41f4940901bd98a92e9014b",
         "boefje": {

--- a/tests/examples/scheduler/pop_response_normalizer.json
+++ b/tests/examples/scheduler/pop_response_normalizer.json
@@ -1,7 +1,10 @@
 {
+  "id": "60da7d4ff41f4940901bd98a92e9014b",
   "priority": 1,
+  "scheduler_id": "normalizer-_dev",
+  "hash": "7e698c377cfd85015c0d7086b76b76b4",
   "data": {
-    "id": "70da7d4ff41f4940901bd98a92e9014b",
+    "id": "60da7d4ff41f4940901bd98a92e9014b",
     "raw_data": {
         "id": "60da7d4ff41f4940901bd98a92e9014a",
         "boefje_meta": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from pydantic import parse_raw_as
 
 from boefjes.app import SchedulerRuntimeManager
-from boefjes.clients.scheduler_client import SchedulerClientInterface, Task, Queue
+from boefjes.clients.scheduler_client import SchedulerClientInterface, QueuePrioritizedItem, Queue
 from boefjes.config import Settings
 from boefjes.job_models import BoefjeMeta, NormalizerMeta
 from boefjes.runtime_interfaces import Handler, StopWorking, RuntimeManager
@@ -22,12 +22,12 @@ class MockSchedulerClient(SchedulerClientInterface):
     def get_queues(self) -> List[Queue]:
         return parse_raw_as(List[Queue], self.boefje_responses.pop(0))
 
-    def pop_task(self, queue: str) -> Optional[Task]:
+    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
         if RuntimeManager.Queue.BOEFJES.value in queue and self.boefje_responses:
-            return parse_raw_as(Task, self.boefje_responses.pop(0))
+            return parse_raw_as(QueuePrioritizedItem, self.boefje_responses.pop(0))
 
         if RuntimeManager.Queue.NORMALIZERS.value in queue and self.normalizer_responses:
-            return parse_raw_as(Task, self.normalizer_responses.pop(0))
+            return parse_raw_as(QueuePrioritizedItem, self.normalizer_responses.pop(0))
 
 
 class MockHandler(Handler):
@@ -61,7 +61,7 @@ class MockHandler(Handler):
             return [parse_raw_as(Union[BoefjeMeta, NormalizerMeta], x) for x in f]
 
 
-class RuntimeTest(TestCase):
+class AppTest(TestCase):
     def setUp(self) -> None:
         # This tests multiprocessing, so we use a file for interprocess communication
         self.tempdir = tempfile.TemporaryDirectory()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -90,7 +90,7 @@ class AppTest(TestCase):
             return self.scheduler_client
 
         self.runtime = SchedulerRuntimeManager(
-            self.item_handler, client_factory, Settings(pool_size=1, poll_interval=0.01), "DEBUG", exit_on_error=True
+            self.item_handler, client_factory, Settings(pool_size=1, poll_interval=0.01), "DEBUG"
         )
 
     def tearDown(self) -> None:
@@ -145,7 +145,7 @@ class AppTest(TestCase):
         self.assertEqual(2, len(items))
 
         patched_tasks = self.scheduler_client.get_all_patched_tasks()
-        self.assertEqual(4, len(patched_tasks))
+        self.assertEqual(6, len(patched_tasks))
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "completed"], patched_tasks[0])
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "completed"], patched_tasks[1])
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "failed"], patched_tasks[2])
@@ -161,13 +161,15 @@ class AppTest(TestCase):
         self.assertEqual(2, len(items))
 
         patched_tasks = self.scheduler_client.get_all_patched_tasks()
-        self.assertEqual(4, len(patched_tasks))
+        self.assertEqual(6, len(patched_tasks))
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "completed"], patched_tasks[0])
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "completed"], patched_tasks[1])
         self.assertEqual(
             ["70da7d4f-f41f-4940-901b-d98a92e9014b", "failed"], patched_tasks[2]
         )  # Handler starts raising an Exception from the second call onward
         self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "failed"], patched_tasks[3])
+        self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "failed"], patched_tasks[4])
+        self.assertEqual(["70da7d4f-f41f-4940-901b-d98a92e9014b", "failed"], patched_tasks[5])
 
     def test_null(self) -> None:
         """This tests ensures we test the behaviour when the scheduler client returns None for the pop_task method"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 from pydantic import parse_raw_as
 
 from boefjes.app import SchedulerRuntimeManager
-from boefjes.clients.scheduler_client import SchedulerClientInterface, QueuePrioritizedItem, Queue
+from boefjes.clients.scheduler_client import SchedulerClientInterface, QueuePrioritizedItem, Queue, TaskStatus
 from boefjes.config import Settings
 from boefjes.job_models import BoefjeMeta, NormalizerMeta
 from boefjes.runtime_interfaces import Handler, StopWorking, RuntimeManager
@@ -22,12 +22,15 @@ class MockSchedulerClient(SchedulerClientInterface):
     def get_queues(self) -> List[Queue]:
         return parse_raw_as(List[Queue], self.boefje_responses.pop(0))
 
-    def pop_task(self, queue: str) -> Optional[QueuePrioritizedItem]:
+    def pop_item(self, queue: str) -> Optional[QueuePrioritizedItem]:
         if RuntimeManager.Queue.BOEFJES.value in queue and self.boefje_responses:
             return parse_raw_as(QueuePrioritizedItem, self.boefje_responses.pop(0))
 
         if RuntimeManager.Queue.NORMALIZERS.value in queue and self.normalizer_responses:
             return parse_raw_as(QueuePrioritizedItem, self.normalizer_responses.pop(0))
+
+    def patch_task(self, task_id: str, status: TaskStatus) -> None:
+        pass
 
 
 class MockHandler(Handler):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -109,7 +109,7 @@ class TaskTest(TestCase):
 
         local_repository = LocalPluginRepository(Path(__file__).parent / "modules")
 
-        with pytest.raises(RuntimeError):  # Bytes still saves exceptions before they ar reraised
+        with pytest.raises(RuntimeError):  # Bytes still saves exceptions before they are reraised
             BoefjeHandler(LocalBoefjeJobRunner(local_repository), local_repository).handle(meta)
 
         mock_bytes_api_client.save_boefje_meta.assert_called_once_with(meta)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import pytest
 import sys
 from typing import List
 from unittest import TestCase, mock
@@ -107,7 +108,9 @@ class TaskTest(TestCase):
         )
 
         local_repository = LocalPluginRepository(Path(__file__).parent / "modules")
-        BoefjeHandler(LocalBoefjeJobRunner(local_repository), local_repository).handle(meta)
+
+        with pytest.raises(RuntimeError):  # Bytes still saves exceptions before they ar reraised
+            BoefjeHandler(LocalBoefjeJobRunner(local_repository), local_repository).handle(meta)
 
         mock_bytes_api_client.save_boefje_meta.assert_called_once_with(meta)
         mock_bytes_api_client.save_raw.assert_called_once_with(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -115,7 +115,7 @@ class TaskTest(TestCase):
         mock_bytes_api_client.save_boefje_meta.assert_called_once_with(meta)
         mock_bytes_api_client.save_raw.assert_called_once_with(
             "some-random-job-id",
-            "dummy error",
+            "Boefje failed",
             {
                 "error/boefje",
                 "dummy_boefje_runtime_exception",


### PR DESCRIPTION
This fixes the Tasks being stuck on dispatched and makes the task status (hopefully) more stable in the end: we move the responsibility of updating the task status to `completed` or `failed` to where tasks are handled: in the boefje/normalizer app. More exceptions are raised towards the app to handle patching the task status. Also this means the scheduler has to do less when it receives messages from Bytes (@jpbruinsslot).

Solves https://github.com/minvws/nl-kat-coordination/issues/136

By `chmod`-ing the `bytes-data` directory to  400 I was able to recreate the errors in Bytes we were seeing that were not handled well, and now in the logs we see the application updating the task status after the errror:

![fixed](https://user-images.githubusercontent.com/46660228/217548967-297bef57-0343-4547-933c-0f54165e340f.png)

Running a boefje three times and then `chmod`-ing to 750 again for the last try makes it work like a charm:

![fix2right](https://user-images.githubusercontent.com/46660228/217549332-0055151f-1f62-4695-9551-8fe06624609a.png)


